### PR TITLE
TokenFactory and SampleConsumer

### DIFF
--- a/SampleConsumer.mon
+++ b/SampleConsumer.mon
@@ -1,5 +1,7 @@
-
-/** This monitor is a sample consumer of an access token. It registers its interest in token and keeps getting updates callback for that token */
+/** 
+*	This monitor is a sample consumer of an access token. 
+*	It registers its interest in token and keeps getting updates callback for that token
+*/
 monitor SampleConsumer {
 	
 	string token := "";
@@ -29,7 +31,8 @@ monitor SampleConsumer {
 		on all LoopEvent() {
 			log currentTime.toString() at INFO;
 			if ("" = token) {
-				log "Consumer: Cannot use token as it has expired and invalid. I will wait for a Token refresh before using it" at WARN;
+				log "Consumer: Cannot use token as it has expired and invalid." +
+						" I will wait for a Token refresh before using it" at WARN;
 				on TokenRefreshed() {
 					useToken();
 				}

--- a/SampleConsumer.mon
+++ b/SampleConsumer.mon
@@ -1,0 +1,65 @@
+
+/** This monitor is a sample consumer of an access token. It registers its interest in token and keeps getting updates callback for that token */
+monitor SampleConsumer {
+	
+	string token := "";
+	TokenRegistrar registrar;
+	
+	event TokenRefreshed {}
+	event LoopEvent {}
+	
+	integer loopCounter := 0;
+	action onload() {
+		log "Loaded monitor SampleConsumer" at INFO;
+		spawn startConsumingToken() to context("some_context");
+	}
+	
+	action refreshToken(string tokenValue) {
+		token := tokenValue;
+		if  (token != "") {
+			send TokenRefreshed() to context.current();	
+		}
+	}
+	
+	action startConsumingToken() {
+		// Register for token updates
+		registrar := TokenRegistrar.registerInterest("token_tag_for_uri_abc", refreshToken);
+		
+		// Start using token
+		on all LoopEvent() {
+			log currentTime.toString() at INFO;
+			if ("" = token) {
+				log "Consumer: Cannot use token as it has expired and invalid. I will wait for a Token refresh before using it" at WARN;
+				on TokenRefreshed() {
+					useToken();
+				}
+			} else {
+				useToken();
+			}
+		}
+		send LoopEvent() to context.current();
+	}
+	
+	action useToken() {
+		//we can use this valid token in our requests here
+		log "Consumer: Found a valid token: " + token at INFO;
+		
+		loopCounter := loopCounter + 1;
+		// Some condition after which we no longer need token and can directly unregisterInterest or 
+		// call die on monitor and unregisterInterest in the ondie()
+		if (loopCounter = 20) {
+			die;
+			//registrar.unregisterInterest();
+		} else {
+			log currentTime.toString() at INFO;
+			// Add a small delay before the next token use
+			on wait(5.0) {
+				send LoopEvent() to context.current();
+			}	
+		}
+	}
+	
+	action ondie() {
+		registrar.unregisterInterest();
+	}
+}

--- a/TokenFactory.mon
+++ b/TokenFactory.mon
@@ -1,50 +1,69 @@
 using com.apama.cumulocity.Event;
 
-/** @private Internal event TokenRegistrationRequest */
+/** 
+*	@private Internal event TokenRegistrationRequest
+*/
 event TokenRegistrationRequest {
 	constant string SEND_CHANNEL := "TOKEN_FACTORY_IN_CHANNEL";
 	string eventType;
 	integer reqId;
 }
 
-/** @private Internal event TokenRegistrationResponse */
+/**
+*	@private Internal event TokenRegistrationResponse
+*/
 event TokenRegistrationResponse {
 	constant string SUBSCRIBE_CHANNEL := "TOKEN_FACTORY_OUT_CHANNEL";
 	integer reqId;
 	string token;
 }
 
-/** @private Internal event TokenUpdate */
+/**
+*	@private Internal event TokenUpdate
+*/
 event TokenUpdate {
 	constant string SUBSCRIBE_CHANNEL := "TOKEN_FACTORY_OUT_CHANNEL";
 	string eventType;
 	string token;
 }
 
-/** @private Internal event RegistrationCancellationReq */
+/**
+*	@private Internal event RegistrationCancellationReq
+*/
 event RegistrationCancellationReq {
 	constant string SEND_CHANNEL := "TOKEN_FACTORY_IN_CHANNEL";
 	string eventType;
 }
 
-/** Use TokenRegistrar.registerInterest to get update callbacks for a particular token */
+/**
+*	Use TokenRegistrar.registerInterest to get update callbacks for a particular token
+*/
 event TokenRegistrar {
 	
-	/** @private */ listener responseListener;
-	/** @private */ listener updateListener;
-	/** @private */ string eventType;
+	/** @private */ 
+	listener responseListener;
 	
-	/** A static method to be called by any consumers which are interested in getting refresh updates for a particular token
+	/** @private */ 
+	listener updateListener;
+	
+	/** @private */ 
+	string eventType;
+	
+	/** 
+	*	A static method to be called by any consumers which are interested in 
+	*	getting refresh updates for a particular token
 	*	@return a TokenRegistrar on which you can call unregisterInterest later
 	*/
-	static action registerInterest(string eventType, action<string> callback) returns TokenRegistrar {
-		
-		// For simplification, only 2 channels are utilized by all Internal events: TOKEN_FACTORY_IN_CHANNEL, TOKEN_FACTORY_OUT_CHANNEL
+	static action registerInterest(string eventType, action<string> callback) 
+														returns TokenRegistrar {
+		//	For simplification, only 2 channels are utilized by all Internal 
+		//	events: TOKEN_FACTORY_IN_CHANNEL, TOKEN_FACTORY_OUT_CHANNEL
 		monitor.subscribe(TokenRegistrationResponse.SUBSCRIBE_CHANNEL);
 		
 		integer reqId := integer.getUnique();
 		
-		listener responseListener := on TokenRegistrationResponse(reqId=reqId) as resp and not TokenUpdate(eventType=eventType) {
+		listener responseListener := on TokenRegistrationResponse(reqId=reqId) as resp
+					and not TokenUpdate(eventType=eventType) {
 			callback(resp.token);	
 		}
 		
@@ -57,7 +76,8 @@ event TokenRegistrar {
 		return TokenRegistrar(responseListener, updateListener, eventType);
 	}
 	
-	/** A method to be called by consumers when they no longer want update notifications
+	/**
+	*	This method should be called by consumers when they no longer want update notifications
 	*/
 	action unregisterInterest() {
 		updateListener.quit();
@@ -67,7 +87,10 @@ event TokenRegistrar {
 	
 }
 
-/** This monitor is responsible for providing token updates to all of the Token consumers which have registered to updates using Token.registerInterest  */
+/** 
+*	This monitor is responsible for providing token updates to all of the 
+*	Token consumers which have registered to updates using Token.registerInterest
+*/
 monitor TokenFactory {
 
 	action onload() {
@@ -87,7 +110,10 @@ monitor TokenFactory {
 
 	dictionary<string, CacheEntry> tokenCache;
 	
-	/** Listens for TokenRegistrationRequests and keep sending token refresh notifications to respective consumers using TokenUpdates */
+	/** 
+	*	Listens for all Token related requests and keep sending token refresh 
+	*	notifications to respective consumers using TokenUpdates 
+	*/
 	action serveTokenRelatedRequests() {
 		monitor.subscribe(TokenRegistrationRequest.SEND_CHANNEL);
 		monitor.subscribe(Event.SUBSCRIBE_CHANNEL);
@@ -100,6 +126,7 @@ monitor TokenFactory {
 					// if "token" and/or "expirationTime" fields are missing, consider it as an expired token
 					string token := "";
 					float expirationTime := e.params.getOr("expirationTime", 0.0).valueToString().toFloat();
+					// Read the token only if it is still valid
 					if (expirationTime > currentTime) {
 						token := e.params.getOr("token", "").valueToString();
 					}
@@ -110,8 +137,10 @@ monitor TokenFactory {
 				// Increment the number of consumers by 1
 				tokenCache[req.eventType].consumers := tokenCache[req.eventType].consumers + 1;
 			}
-			// Always respond with the cached value even if it is invalid. A new TokenUpdate notification will be sent on every refresh
-			send TokenRegistrationResponse(req.reqId, tokenCache[req.eventType].token) to TokenRegistrationResponse.SUBSCRIBE_CHANNEL;
+			//	Always respond with the cached value even if it is invalid.
+			//	A new TokenUpdate notification will be sent on every future refresh
+			send TokenRegistrationResponse(req.reqId, tokenCache[req.eventType].token) to 
+												TokenRegistrationResponse.SUBSCRIBE_CHANNEL;
 		}
 		
 		on all RegistrationCancellationReq() as req {
@@ -131,9 +160,12 @@ monitor TokenFactory {
 		}
 	}
 	
-	/** Starts an expiration timer on a cache key.*/
+	/** 
+	*	Starts an expiration timer on a cache key.
+	*/
 	action startExpiryTimer(string key) {
-		// we can configure an additional wait to log a early warning, trigger a refresh-token subroutine and notify the person responsible via SMS/EMAIL
+		//	we can configure an additional wait to log a early warning, 
+		//	trigger a refresh-token subroutine or notify the person responsible via SMS/EMAIL
 		
 		on wait(tokenCache[key].expiration - currentTime) and not StopEventListener(type=key){
 			// check if the token was refreshed during this wait
@@ -149,7 +181,10 @@ monitor TokenFactory {
 		}
 	}
 	
-	/** Updates the caches on any token refreshes received as events and notifies the consumers by sending a TokenRegistrationResponse with reqid set to 0 */ 
+	/** 
+	*	Updates the caches on any token refreshes received as events and notifies 
+	*	the consumers by sending a TokenUpdate with eventType=key
+	*/ 
 	action updateAndNotify(string key, string tokenValue, float expirationTime) {
 		CacheEntry cachedEntry := tokenCache[key];
 		cachedEntry.token := tokenValue;

--- a/TokenFactory.mon
+++ b/TokenFactory.mon
@@ -1,0 +1,159 @@
+using com.apama.cumulocity.Event;
+
+/** @private Internal event TokenRegistrationRequest */
+event TokenRegistrationRequest {
+	constant string SEND_CHANNEL := "TOKEN_FACTORY_IN_CHANNEL";
+	string eventType;
+	integer reqId;
+}
+
+/** @private Internal event TokenRegistrationResponse */
+event TokenRegistrationResponse {
+	constant string SUBSCRIBE_CHANNEL := "TOKEN_FACTORY_OUT_CHANNEL";
+	integer reqId;
+	string token;
+}
+
+/** @private Internal event TokenUpdate */
+event TokenUpdate {
+	constant string SUBSCRIBE_CHANNEL := "TOKEN_FACTORY_OUT_CHANNEL";
+	string eventType;
+	string token;
+}
+
+/** @private Internal event RegistrationCancellationReq */
+event RegistrationCancellationReq {
+	constant string SEND_CHANNEL := "TOKEN_FACTORY_IN_CHANNEL";
+	string eventType;
+}
+
+/** Use TokenRegistrar.registerInterest to get update callbacks for a particular token */
+event TokenRegistrar {
+	
+	/** @private */ listener responseListener;
+	/** @private */ listener updateListener;
+	/** @private */ string eventType;
+	
+	/** A static method to be called by any consumers which are interested in getting refresh updates for a particular token
+	*	@return a TokenRegistrar on which you can call unregisterInterest later
+	*/
+	static action registerInterest(string eventType, action<string> callback) returns TokenRegistrar {
+		
+		// For simplification, only 2 channels are utilized by all Internal events: TOKEN_FACTORY_IN_CHANNEL, TOKEN_FACTORY_OUT_CHANNEL
+		monitor.subscribe(TokenRegistrationResponse.SUBSCRIBE_CHANNEL);
+		
+		integer reqId := integer.getUnique();
+		
+		listener responseListener := on TokenRegistrationResponse(reqId=reqId) as resp and not TokenUpdate(eventType=eventType) {
+			callback(resp.token);	
+		}
+		
+		listener updateListener := on all TokenUpdate(eventType=eventType) as resp {
+			callback(resp.token);
+		}
+		
+		send TokenRegistrationRequest(eventType, reqId) to TokenRegistrationRequest.SEND_CHANNEL;
+		
+		return TokenRegistrar(responseListener, updateListener, eventType);
+	}
+	
+	/** A method to be called by consumers when they no longer want update notifications
+	*/
+	action unregisterInterest() {
+		updateListener.quit();
+		responseListener.quit();
+		send RegistrationCancellationReq(eventType) to RegistrationCancellationReq.SEND_CHANNEL;
+	}
+	
+}
+
+/** This monitor is responsible for providing token updates to all of the Token consumers which have registered to updates using Token.registerInterest  */
+monitor TokenFactory {
+
+	action onload() {
+		log "Loaded monitor TokenFactory" at INFO;
+		spawn serveTokenRelatedRequests() to context("new_context");
+	}
+	
+	event CacheEntry {
+		string token;
+		float expiration;
+		integer consumers;
+	}
+
+	event StopEventListener {
+		string type;
+	}
+
+	dictionary<string, CacheEntry> tokenCache;
+	
+	/** Listens for TokenRegistrationRequests and keep sending token refresh notifications to respective consumers using TokenUpdates */
+	action serveTokenRelatedRequests() {
+		monitor.subscribe(TokenRegistrationRequest.SEND_CHANNEL);
+		monitor.subscribe(Event.SUBSCRIBE_CHANNEL);
+		on all TokenRegistrationRequest() as req {
+			if not tokenCache.hasKey(req.eventType) {
+				// Add a new cachedEntry in the caches with an invalid token
+				tokenCache.add(req.eventType, CacheEntry("", 0.0, 1));
+				
+				on all Event(type=req.eventType) as e and not StopEventListener(type=req.eventType) {
+					// if "token" and/or "expirationTime" fields are missing, consider it as an expired token
+					string token := "";
+					float expirationTime := e.params.getOr("expirationTime", 0.0).valueToString().toFloat();
+					if (expirationTime > currentTime) {
+						token := e.params.getOr("token", "").valueToString();
+					}
+					updateAndNotify(req.eventType, token, expirationTime);
+					startExpiryTimer(req.eventType);
+				}
+			} else {
+				// Increment the number of consumers by 1
+				tokenCache[req.eventType].consumers := tokenCache[req.eventType].consumers + 1;
+			}
+			// Always respond with the cached value even if it is invalid. A new TokenUpdate notification will be sent on every refresh
+			send TokenRegistrationResponse(req.reqId, tokenCache[req.eventType].token) to TokenRegistrationResponse.SUBSCRIBE_CHANNEL;
+		}
+		
+		on all RegistrationCancellationReq() as req {
+			string cacheKey := req.eventType;
+			if not tokenCache.hasKey(cacheKey) {
+				log "Trying to unregisterInterest with an invalid TokenRegistrar."
+					+ " Use TokenRegistrar.registerInterest() to get a valid registrar" at WARN;
+				return;
+			}
+			
+			CacheEntry cachedEntry := tokenCache[cacheKey];
+			cachedEntry.consumers := cachedEntry.consumers - 1;
+			if (cachedEntry.consumers = 0) {
+				send StopEventListener(req.eventType) to context.current();
+				tokenCache.remove(req.eventType);
+			}
+		}
+	}
+	
+	/** Starts an expiration timer on a cache key.*/
+	action startExpiryTimer(string key) {
+		// we can configure an additional wait to log a early warning, trigger a refresh-token subroutine and notify the person responsible via SMS/EMAIL
+		
+		on wait(tokenCache[key].expiration - currentTime) and not StopEventListener(type=key){
+			// check if the token was refreshed during this wait
+			CacheEntry cachedEntry := tokenCache[key];
+			if (currentTime >= cachedEntry.expiration) {
+				log "Token with " + key + " as key has expired and no longer valid." at WARN;
+				// set token value as empty which implies invalid token
+				cachedEntry.token := "";
+				
+				// Notify the consumers of this token
+				send TokenUpdate(key, cachedEntry.token) to TokenRegistrationResponse.SUBSCRIBE_CHANNEL;
+			}
+		}
+	}
+	
+	/** Updates the caches on any token refreshes received as events and notifies the consumers by sending a TokenRegistrationResponse with reqid set to 0 */ 
+	action updateAndNotify(string key, string tokenValue, float expirationTime) {
+		CacheEntry cachedEntry := tokenCache[key];
+		cachedEntry.token := tokenValue;
+		cachedEntry.expiration := expirationTime;
+		send TokenUpdate(key, cachedEntry.token) to TokenUpdate.SUBSCRIBE_CHANNEL;	
+	}
+}

--- a/TokenFactory.mon
+++ b/TokenFactory.mon
@@ -55,7 +55,7 @@ event TokenRegistrar {
 	*	@return a TokenRegistrar on which you can call unregisterInterest later
 	*/
 	static action registerInterest(string eventType, action<string> callback) 
-														returns TokenRegistrar {
+		returns TokenRegistrar {
 		//	For simplification, only 2 channels are utilized by all Internal 
 		//	events: TOKEN_FACTORY_IN_CHANNEL, TOKEN_FACTORY_OUT_CHANNEL
 		monitor.subscribe(TokenRegistrationResponse.SUBSCRIBE_CHANNEL);
@@ -140,7 +140,7 @@ monitor TokenFactory {
 			//	Always respond with the cached value even if it is invalid.
 			//	A new TokenUpdate notification will be sent on every future refresh
 			send TokenRegistrationResponse(req.reqId, tokenCache[req.eventType].token) to 
-												TokenRegistrationResponse.SUBSCRIBE_CHANNEL;
+							TokenRegistrationResponse.SUBSCRIBE_CHANNEL;
 		}
 		
 		on all RegistrationCancellationReq() as req {


### PR DESCRIPTION
EPL code for refreshing the access tokens in memory without having to redeploy the EPL app.